### PR TITLE
Fixed lockowner slowdown

### DIFF
--- a/Hop.h
+++ b/Hop.h
@@ -106,7 +106,7 @@ enum HopZoneColor
 // is being unlocked.
 #define HOP_PROF_MUTEX_UNLOCK( x ) __HOP_MUTEX_UNLOCK_EVENT( x )
 
-#define HOP_ZONE_COLOR( x ) __HOP_ZONE_COLOR_GUARD( __LINE__, ( x ) )
+#define HOP_ZONE( x ) __HOP_ZONE_GUARD( __LINE__, ( x ) )
 
 // Set the name of the current thread in the profiler. Only the first call will
 // be considered for each thread.
@@ -147,8 +147,6 @@ enum HopZoneColor
                        |_||_|\___/|_|
 */
 #include <stdint.h>
-
-#include <cassert> // TO REMOVE
 
 // Useful macros
 #define HOP_VERSION 0.5f
@@ -460,7 +458,7 @@ class ZoneGuard
    hop::LockWaitGuard __HOP_COMBINE( hopMutexLock, LINE ) ARGS
 #define __HOP_MUTEX_UNLOCK_EVENT( x ) \
    hop::ClientManager::UnlockEvent( x, hop::getTimeStamp() );
-#define __HOP_ZONE_COLOR_GUARD( LINE, ARGS ) \
+#define __HOP_ZONE_GUARD( LINE, ARGS ) \
    hop::ZoneGuard __HOP_COMBINE( hopZoneGuard, LINE ) ARGS
 
 #define __HOP_COMBINE( X, Y ) X##Y
@@ -854,14 +852,14 @@ SharedMemory::ConnectionState SharedMemory::create( const HOP_CHAR* exeName, siz
       _isConsumer = isConsumer;
 
       // Create shared mem name
-	  HOP_STRNCPYW( _sharedMemPath, HOP_SHARED_MEM_PREFIX, HOP_STRLEN( HOP_SHARED_MEM_PREFIX ) + 1 );
-	  HOP_STRNCATW(
+     HOP_STRNCPYW( _sharedMemPath, HOP_SHARED_MEM_PREFIX, HOP_STRLEN( HOP_SHARED_MEM_PREFIX ) + 1 );
+     HOP_STRNCATW(
           _sharedMemPath,
           exeName,
           HOP_SHARED_MEM_MAX_NAME_SIZE - HOP_STRLEN( HOP_SHARED_MEM_PREFIX ) - 1 );
 
-	  HOP_STRNCPYW( _sharedSemPath, _sharedMemPath, HOP_SHARED_MEM_MAX_NAME_SIZE );
-	  HOP_STRNCATW( _sharedSemPath, HOP_SHARED_SEM_SUFFIX, HOP_SHARED_MEM_MAX_NAME_SIZE - HOP_STRLEN( _sharedSemPath ) -1 );
+     HOP_STRNCPYW( _sharedSemPath, _sharedMemPath, HOP_SHARED_MEM_MAX_NAME_SIZE );
+     HOP_STRNCATW( _sharedSemPath, HOP_SHARED_SEM_SUFFIX, HOP_SHARED_MEM_MAX_NAME_SIZE - HOP_STRLEN( _sharedSemPath ) -1 );
 
       // Open semaphore
       _semaphore = openSemaphore( _sharedSemPath, &state );

--- a/TimelineTrack.cpp
+++ b/TimelineTrack.cpp
@@ -335,7 +335,7 @@ void TimelineTrack::addUnlockEvents(const std::vector<UnlockEvent>& unlockEvents
       const auto lockWaitsIdx = _lockWaitsPerMutex.find( ue.mutexAddress );
       if(lockWaitsIdx != _lockWaitsPerMutex.end() )
       {
-         std::vector< size_t >& lockwaitIdx = lockWaitsIdx->second;
+         std::vector< TimeStamp >& lockwaitIdx = lockWaitsIdx->second;
          size_t i = 0;
          for (; i < lockwaitIdx.size(); ++i)
          {

--- a/TimelineTrack.h
+++ b/TimelineTrack.h
@@ -36,7 +36,7 @@ struct TimelineTrack
    LockWaitData _lockWaits;
    CoreEventData _coreEvents;
 
-   std::unordered_map< void*, size_t > _lockWaitsPerMutex;
+   std::unordered_map< void*, std::vector< TimeStamp > > _lockWaitsPerMutex;
 
    struct HighlightDrawInfo
    {

--- a/TimelineTrack.h
+++ b/TimelineTrack.h
@@ -9,6 +9,7 @@
 
 #include <tuple>
 #include <vector>
+#include <unordered_map>
 
 namespace hop
 {
@@ -34,6 +35,8 @@ struct TimelineTrack
    TraceData _traces;
    LockWaitData _lockWaits;
    CoreEventData _coreEvents;
+
+   std::unordered_map< void*, size_t > _lockWaitsPerMutex;
 
    struct HighlightDrawInfo
    {

--- a/Utils.h
+++ b/Utils.h
@@ -11,7 +11,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-// #define HOP_ASSERT_IS_SORTED
+#define HOP_ASSERT_IS_SORTED
 
 namespace hop
 {

--- a/Utils.h
+++ b/Utils.h
@@ -11,7 +11,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define HOP_ASSERT_IS_SORTED
+//#define HOP_ASSERT_IS_SORTED
 
 namespace hop
 {

--- a/test_clients/heavy_rec.cpp
+++ b/test_clients/heavy_rec.cpp
@@ -29,13 +29,17 @@ MyMutex g_mutex;
 
 bool g_run = true;
 
+static const int RECURSION_COUNT = 20;
+thread_local std::vector< MyMutex > mxs( RECURSION_COUNT + 1 );
+
 void rec( int& i )
 {
    HOP_PROF_FUNC();
    while( i > 0 )
    {
-      //std::lock_guard<MyMutex> g{g_mutex};
-      std::this_thread::sleep_for(std::chrono::microseconds(1));
+      std::lock_guard<MyMutex> g{mxs[i]};
+      if( i%5 == 0 )
+         std::this_thread::sleep_for(std::chrono::microseconds(1));
       rec(--i);
    }
 }
@@ -43,7 +47,7 @@ void rec( int& i )
 void startRec()
 {
    HOP_PROF_FUNC();
-   int recCount = 50;
+   int recCount = RECURSION_COUNT;
    rec( recCount );
 }
 


### PR DESCRIPTION
We might still want to defer the work of associated unlock event to the lockwaits as it is still not as fast as I would like it to be