### PR TITLE
Fixed undefined behavior due to misalignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,10 @@ set( CMAKE_VERBOSE_MAKEFILE on )
 #####################
 ### Asan
 #####################
-SET(ASAN OFF CACHE BOOL "Enable Address Sanitizer")
-if(ASAN)
-   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
-   set (CMAKE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
+SET(SAN CACHE STRING "Enable Specified Sanitizer")
+if(SAN)
+   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=${SAN}")
+   set (CMAKE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=${SAN}")
 endif()
 
 #####################

--- a/Hop.h
+++ b/Hop.h
@@ -1270,7 +1270,7 @@ class Client
       const bool msgWayToBig = size > HOP_SHARED_MEM_SIZE;
       if( !msgWayToBig )
       {
-         const size_t paddedSize = (size + 7)& ~7;
+         const size_t paddedSize = alignOn( size, 8 );
          const ssize_t offset = ringbuf_acquire( ringbuf, _worker, paddedSize );
          if( offset != -1 )
          {

--- a/Hop.h
+++ b/Hop.h
@@ -149,7 +149,7 @@ enum HopZoneColor
 #include <stdint.h>
 
 // Useful macros
-#define HOP_VERSION 0.6f
+#define HOP_VERSION 0.61f
 #define HOP_CONSTEXPR constexpr
 #define HOP_NOEXCEPT noexcept
 #define HOP_STATIC_ASSERT static_assert
@@ -1188,7 +1188,7 @@ class Client
       {
          const size_t newEntryPos = _stringData.size();
          assert( (newEntryPos & 7) == 0 ); // Make sure we are 8 byte aligned
-         
+
          const size_t alignedStrLen = alignOn( strLen + 1, 8 );
 
          _stringData.resize( newEntryPos + sizeof( StrPtr_t ) + alignedStrLen );

--- a/StringDb.cpp
+++ b/StringDb.cpp
@@ -92,7 +92,7 @@ std::vector< size_t > StringDb::findStringIndexMatching( const char* substrToFin
 {
    std::vector< size_t > indices;
    indices.reserve( 64 );
-   size_t i = 1;
+   size_t i = 8;
    while( i < _strData.size() )
    {
       const auto length = alignOn( strlen( &_strData[i] ) + 1, 8 );


### PR DESCRIPTION
When the string are copied into the string table, no padding was added and therefore could create pointers that were not aligned on 8 bytes. I have added dummy padding to every string added to the table so it ends on a 8 byte boundary.