### PR TITLE
Process name truncation

### DIFF
--- a/common/platform/Platform_Unix.cpp
+++ b/common/platform/Platform_Unix.cpp
@@ -8,6 +8,11 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+/*
+   The comm= and cmd parameter passed to the 'o' argument of the grep acts differently
+   on Linux and on MacOs. Since we want to have the full name of the executable we need
+   to use these 2 versions for each platform
+*/
 #ifdef __APPLE__
 #define HOP_GREP_CMD "comm="
 #else
@@ -58,8 +63,7 @@ ProcessInfo getProcessInfoFromProcessName( const char* name )
        * grep process from the result. On MacOs the process name also contains the path, we
        * thus have to check for a preceding '/'
        */
-      snprintf( cmd, sizeof( cmd ), "ps -Ao pid," HOP_GREP_CMD " | grep -E '[0-9]+ \\.?(?:\\/\\S+)?/%s$'" , name );
-
+      snprintf( cmd, sizeof( cmd ), "ps -Ao pid," HOP_GREP_CMD " | grep -E '[0-9]+ \\.?\\/?\\S*\\/?%s\\b.*'" , name );
       // Get name from PID
       if( FILE* fp = popen( cmd, "r" ) )
       {

--- a/common/platform/Platform_Unix.cpp
+++ b/common/platform/Platform_Unix.cpp
@@ -52,7 +52,7 @@ ProcessInfo getProcessInfoFromProcessName( const char* name )
        * grep process from the result. On MacOs the process name also contains the path, we
        * thus have to check for a preceding '/'
        */
-      snprintf( cmd, sizeof( cmd ), "ps -Ao pid,comm= | grep '[ \\/]%s$' | grep -v grep | awk '{print $1}'", name );
+      snprintf( cmd, sizeof( cmd ), "ps -Ao pid,cmd | grep -E '[0-9]+ \\.?\\/\\S+\\/%s'" , name );
 
       // Get name from PID
       if( FILE* fp = popen( cmd, "r" ) )

--- a/common/platform/Platform_Unix.cpp
+++ b/common/platform/Platform_Unix.cpp
@@ -8,6 +8,12 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#ifdef __APPLE__
+#define HOP_GREP_CMD "comm="
+#else
+#define HOP_GREP_CMD "cmd"
+#endif
+
 namespace hop
 {
 
@@ -52,7 +58,7 @@ ProcessInfo getProcessInfoFromProcessName( const char* name )
        * grep process from the result. On MacOs the process name also contains the path, we
        * thus have to check for a preceding '/'
        */
-      snprintf( cmd, sizeof( cmd ), "ps -Ao pid,cmd | grep -E '[0-9]+ \\.?\\/\\S+\\/%s'" , name );
+      snprintf( cmd, sizeof( cmd ), "ps -Ao pid," HOP_GREP_CMD " | grep -E '[0-9]+ \\.?(?:\\/\\S+)?/%s$'" , name );
 
       // Get name from PID
       if( FILE* fp = popen( cmd, "r" ) )


### PR DESCRIPTION
On MacOs and Linux the cmd and comm= are not outputting the same data. I have adjusted the command and the regex so that we are able to get the full name of the process as on Linux the comm= would truncate the name to length 15.