### PR TITLE
Removed shared semaphore

### DIFF
--- a/common/Server.h
+++ b/common/Server.h
@@ -44,7 +44,9 @@ class Server
    void getPendingData(PendingData& data);
 
   private:
-   SharedMemory::ConnectionState tryConnect( int32_t pid, uint32_t& reconnectTimeoutMs );
+   // Return wether or not we should retry to connect and fill the connection state
+   bool tryConnect( int32_t pid, SharedMemory::ConnectionState& newState );
+
    // Returns the number of bytes processed
    size_t handleNewMessage( uint8_t* data, size_t maxSize, TimeStamp minTimestamp );
    bool addUniqueThreadName( uint32_t threadIndex, StrPtr_t name );

--- a/hop/Viewer.cpp
+++ b/hop/Viewer.cpp
@@ -354,7 +354,7 @@ static void drawStatusIcon( const ImVec2 drawPos, hop::SharedMemory::ConnectionS
          break;
       case hop::SharedMemory::PERMISSION_DENIED:
          col = ImColor( 0.6f, 0.2f, 0.0f );
-         msg = "Permission to shared memory or semaphore denied";
+         msg = "Permission to shared memory denied";
          break;
       case hop::SharedMemory::INVALID_VERSION:
          col = ImColor( 0.6f, 0.2f, 0.0f );


### PR DESCRIPTION
It was brought to my attention (Thanks Pierre), that the shared semaphore
is probably not needed in a lockless context. Although I don't think it
affects the 'lockless' nature of the ringbuffer (since it only signals
the semaphore and never waits on it), it is simply not needed. At first
I thought it was needed for memory coherency between the process, but
it seems the OS is already handling that like a champ !